### PR TITLE
Version 0.0.3 - Breaking Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 DatumLab/
 Tests/testResults.xml
 testResults.xml
+_Build/SRDSC

--- a/Module/Private/ScriptRunnerAPI/New-ScriptRunnerTarget.ps1
+++ b/Module/Private/ScriptRunnerAPI/New-ScriptRunnerTarget.ps1
@@ -17,8 +17,9 @@ function New-ScriptRunnerTarget {
         Uri = "{0}:8091/ScriptRunner/TargetItem/Default.CreateTarget" -f $ScriptRunnerServerURL
         Method = 'POST'
         Body = @{
-            Comment = ""
-            ComputerName = ""
+            Comment = "This is used by automated SRDSC to create, deploy and update DSC."
+            # . is Simple Run-as Process Mode
+            ComputerName = "."
             DisplayName = "DSC Pull Services"
             OwnerID = 0
             TagNames = @(

--- a/Module/Public/Add-SRDSCNode.ps1
+++ b/Module/Public/Add-SRDSCNode.ps1
@@ -1,203 +1,210 @@
 function Add-SRDSCNode {
-<#
-.Description
-Onboards an Datum Node Endpoint into the DSC Pull Server.
-The calling process uses PowerShell remoting to configure the endpoint (ensure that PowerShell Remoting is enabled on the endpoint).
-The command supports ConfigurationID and Registration Key (Preferred).
-If using a ConfigurationID upon registration, will capture and store the Configuration ID locally on the Pull Server, so the build script can associate the NODE to it's Configuration ID.
-The Registration Key is the preferred way. It onboard the endpoint node and set's the Configuation Name to the  .
+    <#
+    .Description
+    Onboards an Datum Node Endpoint into the DSC Pull Server.
+    The calling process uses PowerShell remoting to configure the endpoint (ensure that PowerShell Remoting is enabled on the endpoint).
+    The command supports ConfigurationID and Registration Key (Preferred).
+    If using a ConfigurationID upon registration, will capture and store the Configuration ID locally on the Pull Server, so the build script can associate the NODE to it's Configuration ID.
+    The Registration Key is the preferred way. It onboard the endpoint node and set's the Configuation Name to the  .
+    
+    If a Pull Server has already been configured on the LCM endpoint, the process won't perform the onboarding process, however it will still return the ConfigurationID.
+    
+    .PARAMETER NodeName
+    The ComputerName Endpoint.
+    
+    .PARAMETER DSCPullServer
+    The PullServer URL Location
+    
+    .PARAMETER UseConfigurationIDs
+    A switch to register the endpoint using ConfigurationIDs, instead of a Pull Server Registration Key.
+    
+    .PARAMETER Force
+    Overwrite any existing LCM configuration and onboard the Node onto the new DSC Pull Server.
+    
+    .EXAMPLE
+    
+    Add-SRDSCNode -NodeName 'NODE01' -DSCPullServer 'HTTP://DSCPULLSERVER01' -Force
+    
+    Forcibly Adds 'NODE01' to the DSCPullServer 'HTTP://DSCPULLSERVER01'
+    
+    .EXAMPLE
+    
+    Add-SRDSCNode -NodeName 'NODE01' -DSCPullServer 'HTTP://DSCPULLSERVER01'
+    
+    Adds 'NODE01' to the DSCPullServer 'HTTP://DSCPULLSERVER01'. If an LCM configuration already exists, stop.
+    
+    .SYNOPSIS
+    Onboards an Endpoint Node into the DSC Pull Server.
+    #>
+        [CmdletBinding()]
+        param (
+            [Parameter(Mandatory)]
+            [String]
+            $NodeName,
+            [Parameter(Mandatory)]
+            [String]
+            $DSCPullServer,
+            [Parameter()]
+            [Switch]
+            $UseConfigurationIDs,        
+            [Switch]
+            $Force
+        )
+    
+        Write-Host "[Add-SRDSCNode] Onboarding $NodeName into $DSCPullServer"
+        Write-Host "[Add-SRDSCNode] PowerShell Remoting to $NodeName to Register LCM to $DSCPullServer"
+    
+        $RegistrationKey = $Global:SRDSC.DSCPullServer.PullServerRegistrationKey
+    
+        # Load the DSC Server Configuration Data
 
-If a Pull Server has already been configured on the LCM endpoint, the process won't perform the onboarding process, however it will still return the ConfigurationID.
+        $invokeCommandParams = @{
+            ArgumentList = $DSCPullServer,$Force,$RegistrationKey,$UseConfigurationIDs
+            ComputerName = $NodeName
+            ErrorAction = 'Stop'
+        }
 
-.PARAMETER NodeName
-The ComputerName Endpoint.
-
-.PARAMETER DSCPullServer
-The PullServer URL Location
-
-.PARAMETER UseConfigurationIDs
-A switch to register the endpoint using ConfigurationIDs, instead of a Pull Server Registration Key.
-
-.PARAMETER Force
-Overwrite any existing LCM configuration and onboard the Node onto the new DSC Pull Server.
-
-.EXAMPLE
-
-Add-SRDSCNode -NodeName 'NODE01' -DSCPullServer 'HTTP://DSCPULLSERVER01' -Force
-
-Forcibly Adds 'NODE01' to the DSCPullServer 'HTTP://DSCPULLSERVER01'
-
-.EXAMPLE
-
-Add-SRDSCNode -NodeName 'NODE01' -DSCPullServer 'HTTP://DSCPULLSERVER01'
-
-Adds 'NODE01' to the DSCPullServer 'HTTP://DSCPULLSERVER01'. If an LCM configuration already exists, stop.
-
-.SYNOPSIS
-Onboards an Endpoint Node into the DSC Pull Server.
-#>
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory)]
-        [String]
-        $NodeName,
-        [Parameter(Mandatory)]
-        [String]
-        $DSCPullServer,
-        [Parameter()]
-        [Switch]
-        $UseConfigurationIDs,        
-        [Switch]
-        $Force
-    )
-
-    Write-Host "[Add-SRDSCNode] Onboarding $NodeName into $DSCPullServer"
-    Write-Host "[Add-SRDSCNode] PowerShell Remoting to $NodeName to Register LCM to $DSCPullServer"
-
-    $RegistrationKey = $Global:SRDSC.DSCPullServer.PullServerRegistrationKey
-
-    # Load the DSC Server Configuration Data
-    $NodeDSCLCMConfiguration = Invoke-Command -ArgumentList $DSCPullServer,$Force,$RegistrationKey,$UseConfigurationIDs -ComputerName $NodeName -ScriptBlock {
-        param($DSCPullServer, $Force, $RegistrationKey, $UseConfigurationIDs)
-
-        #
-        # Functions
-        #
-
-        function Get-DscSplattedResource {
-            [CmdletBinding()]
-            Param(
-                [String]
-                $ResourceName,
-        
-                [String]
-                $ExecutionName,
-        
-                [hashtable]
-                $Properties
-            )
+        $NodeDSCLCMConfiguration = Invoke-Command @invokeCommandParams -ScriptBlock {
+            param($DSCPullServer, $Force, $RegistrationKey, $UseConfigurationIDs)
+    
+            #
+            # Functions
+            #
+    
+            function Get-DscSplattedResource {
+                [CmdletBinding()]
+                Param(
+                    [String]
+                    $ResourceName,
             
-            $stringBuilder = [System.Text.StringBuilder]::new()
-            $null = $stringBuilder.AppendLine("Param([hashtable]`$Parameters)")
-            $null = $stringBuilder.AppendLine(" $ResourceName $ExecutionName { ")
-            foreach($PropertyName in $Properties.keys) {
-                $null = $stringBuilder.AppendLine("$PropertyName = `$(`$Parameters['$PropertyName'])")
-            }
-            $null = $stringBuilder.AppendLine("}")
-            Write-Debug ("Generated Resource Block = {0}" -f $stringBuilder.ToString())
+                    [String]
+                    $ExecutionName,
             
-            [scriptblock]::Create($stringBuilder.ToString()).Invoke($Properties)
-        }
-        Set-Alias –Name x –Value Get-DscSplattedResource
-
-        #
-        # Main Code Block
-        #
-
-        # Test if DSC has been configured on the endpoint.
-        if ((-not($Force.IsPresent)) -and ($null -ne (Get-DscConfigurationStatus -ErrorAction SilentlyContinue))) {
-            # Otherwise return the DSC Configuration with Configuration ID
-            return Get-DscLocalConfigurationManager            
-        }
-
-        
-        #
-        # Compile the DSC Resource
-        #
-
-        #
-        # Settings Resource       
-
-        $DSCResourceSettings = @{
-            RefreshMode = 'Pull'
-            RefreshFrequencyMins = 30
-            RebootNodeIfNeeded = $true          
-        }
-
-        #
-        # ConfigurationRepositoryWeb Resource
-
-        $DSCResourceConfigurationRepositoryWeb = @{
-            ServerURL = 'https://{0}:8080/PSDSCPullServer.svc' -f $DSCPullServer            
-        }
-
-        #
-        # Apply Logic. If Configuration ID's are set, use Configuration Id's
-        # Otherwise use registration.
-
-        # If ConfigurationID's have been specified. Add them in!
-        if ($UseConfigurationIDs.IsPresent) {
-            $DSCResourceSettings.ConfigurationID = [guid]::NewGuid().Guid  
-        } else {
-            $DSCResourceConfigurationRepositoryWeb.RegistrationKey = $RegistrationKey
-            $DSCResourceConfigurationRepositoryWeb.ConfigurationNames = @($ENV:COMPUTERNAME)  
-        }
-
-        #
-        # Define the Configuration
-        #
-
-        [DSCLocalConfigurationManager()]
-        configuration PullClientConfigNames
-        {
-
-            Node localhost
-            {
-                    
-                #
-                # Onboard the machine into DSC and Return the LCM Configuration
-                x -ResourceName 'Settings' -Properties $DSCResourceSettings
-                x -ResourceName 'ConfigurationRepositoryWeb' -ExecutionName 'PullSrv' -Properties $DSCResourceConfigurationRepositoryWeb
-
-                ReportServerWeb PullSrv
-                {
-                    ServerURL = 'https://{0}:8080/PSDSCPullServer.svc' -f $DSCPullServer
+                    [hashtable]
+                    $Properties
+                )
+                
+                $stringBuilder = [System.Text.StringBuilder]::new()
+                $null = $stringBuilder.AppendLine("Param([hashtable]`$Parameters)")
+                $null = $stringBuilder.AppendLine(" $ResourceName $ExecutionName { ")
+                foreach($PropertyName in $Properties.keys) {
+                    $null = $stringBuilder.AppendLine("$PropertyName = `$(`$Parameters['$PropertyName'])")
                 }
-
+                $null = $stringBuilder.AppendLine("}")
+                Write-Debug ("Generated Resource Block = {0}" -f $stringBuilder.ToString())
+                
+                [scriptblock]::Create($stringBuilder.ToString()).Invoke($Properties)
             }
-        }
-
-        # Generate the Configuration MOF File
-        PullClientConfigNames -OutputPath C:\Windows\Temp\DSC\ -ErrorAction Stop
-        # Set the LocalConfiguration
-        Set-DscLocalConfigurationManager -Path C:\Windows\Temp\DSC\ -Verbose -ErrorAction Stop
-        # Retrive the ConfigurationID ID
-        Write-Output (Get-DscLocalConfigurationManager)
-
-    }
-
-    Write-Host "[Add-SRDSCNode] PowerShell Remoting Completed."
-    Write-Host "[Add-SRDSCNode] LCM Configuration: $($NodeDSCLCMConfiguration | ConvertTo-Json)"
-
-
-    if ($UseConfigurationIDs.IsPresent) {
-
-        Write-Host "[Add-SRDSCNode] Writing ConfigurationID of Node as [SecureString]"
-
-        #
-        # The LCM Configuration is needed to register the ConfigurationID.
-        # This is used by the datum configuration to rename the mof files
-        $DatumLCMConfiguration = @()
+            Set-Alias -Name x -Value Get-DscSplattedResource
     
-        if (Test-Path -LiteralPath $Global:SRDSC.DatumModule.NodeRegistrationFile) {
-            $NodeRegistrationFile += Import-Clixml -LiteralPath $Global:SRDSC.DatumModule.NodeRegistrationFile
-            # Filter out the existing node node. This enable rewrites
+            #
+            # Main Code Block
+            #
+    
+            # Test if DSC has been configured on the endpoint.
+            if ((-not($Force.IsPresent)) -and ($null -ne (Get-DscConfigurationStatus -ErrorAction SilentlyContinue))) {
+                # Otherwise return the DSC Configuration with Configuration ID
+                return Get-DscLocalConfigurationManager            
+            }
+    
+            
+            #
+            # Compile the DSC Resource
+            #
+    
+            #
+            # Settings Resource       
+    
+            $DSCResourceSettings = @{
+                RefreshMode = 'Pull'
+                RefreshFrequencyMins = 30
+                RebootNodeIfNeeded = $true          
+            }
+    
+            #
+            # ConfigurationRepositoryWeb Resource
+    
+            $DSCResourceConfigurationRepositoryWeb = @{
+                ServerURL = 'https://{0}:8080/PSDSCPullServer.svc' -f $DSCPullServer            
+            }
+    
+            #
+            # Apply Logic. If Configuration ID's are set, use Configuration Id's
+            # Otherwise use registration.
+    
+            # If ConfigurationID's have been specified. Add them in!
+            if ($UseConfigurationIDs.IsPresent) {
+                $DSCResourceSettings.ConfigurationID = [guid]::NewGuid().Guid  
+            } else {
+                $DSCResourceConfigurationRepositoryWeb.RegistrationKey = $RegistrationKey
+                $DSCResourceConfigurationRepositoryWeb.ConfigurationNames = @($ENV:COMPUTERNAME)  
+            }
+    
+            #
+            # Define the Configuration
+            #
+    
+            [DSCLocalConfigurationManager()]
+            configuration PullClientConfigNames
+            {
+    
+                Node localhost
+                {
+                        
+                    #
+                    # Onboard the machine into DSC and Return the LCM Configuration
+                    x -ResourceName 'Settings' -Properties $DSCResourceSettings
+                    x -ResourceName 'ConfigurationRepositoryWeb' -ExecutionName 'PullSrv' -Properties $DSCResourceConfigurationRepositoryWeb
+    
+                    ReportServerWeb PullSrv
+                    {
+                        ServerURL = 'https://{0}:8080/PSDSCPullServer.svc' -f $DSCPullServer
+                    }
+    
+                }
+            }
+    
+            # Generate the Configuration MOF File
+            PullClientConfigNames -OutputPath C:\Windows\Temp\DSC\ -ErrorAction Stop
+            # Set the LocalConfiguration
+            Set-DscLocalConfigurationManager -Path C:\Windows\Temp\DSC\ -Verbose -ErrorAction Stop
+            # Retrive the ConfigurationID ID
+            Write-Output (Get-DscLocalConfigurationManager)
+    
+        }
+    
+        Write-Host "[Add-SRDSCNode] PowerShell Remoting Completed."
+        Write-Host "[Add-SRDSCNode] LCM Configuration: $($NodeDSCLCMConfiguration | ConvertTo-Json)"
+    
+    
+        if ($UseConfigurationIDs.IsPresent) {
+    
+            Write-Host "[Add-SRDSCNode] Writing ConfigurationID of Node as [SecureString]"
+    
+            #
+            # The LCM Configuration is needed to register the ConfigurationID.
+            # This is used by the datum configuration to rename the mof files
             $DatumLCMConfiguration = @()
-            $DatumLCMConfiguration += $NodeRegistrationFile | Where-Object {$_.NodeName -ne $NodeName}
-        }
         
-        $DatumLCMConfiguration += [PSCustomObject]@{
-            NodeName = $NodeName
-            ConfigurationID = [String]$NodeDSCLCMConfiguration.ConfigurationID | ConvertTo-SecureString -AsPlainText -Force
+            if (Test-Path -LiteralPath $Global:SRDSC.DatumModule.NodeRegistrationFile) {
+                $NodeRegistrationFile += Import-Clixml -LiteralPath $Global:SRDSC.DatumModule.NodeRegistrationFile
+                # Filter out the existing node node. This enable rewrites
+                $DatumLCMConfiguration = @()
+                $DatumLCMConfiguration += $NodeRegistrationFile | Where-Object {$_.NodeName -ne $NodeName}
+            }
+            
+            $DatumLCMConfiguration += [PSCustomObject]@{
+                NodeName = $NodeName
+                ConfigurationID = [String]$NodeDSCLCMConfiguration.ConfigurationID | ConvertTo-SecureString -AsPlainText -Force
+            }
+        
+            # Export it again
+            $DatumLCMConfiguration | Export-Clixml -LiteralPath $Global:SRDSC.DatumModule.NodeRegistrationFile
+        
         }
     
-        # Export it again
-        $DatumLCMConfiguration | Export-Clixml -LiteralPath $Global:SRDSC.DatumModule.NodeRegistrationFile
+        Write-Host "[Add-SRDSCNode] Onboarded."
     
     }
-
-    Write-Host "[Add-SRDSCNode] Onboarded."
-
-}
-
-if ($isModule) { Export-ModuleMember -Function Add-SRDSCNode }
+    
+    if ($isModule) { Export-ModuleMember -Function Add-SRDSCNode }

--- a/Module/Public/Add-SRDSCNode.ps1
+++ b/Module/Public/Add-SRDSCNode.ps1
@@ -118,7 +118,8 @@ function Add-SRDSCNode {
             $DSCResourceSettings = @{
                 RefreshMode = 'Pull'
                 RefreshFrequencyMins = 30
-                RebootNodeIfNeeded = $true          
+                RebootNodeIfNeeded = $true  
+                ConfigurationMode = 'ApplyAndAutoCorrect'        
             }
     
             #

--- a/Module/Public/Start-SRDSConfiguration.ps1
+++ b/Module/Public/Start-SRDSConfiguration.ps1
@@ -112,7 +112,7 @@ function Start-SRDSConfiguration {
 
     $MOFFileCopyParams = @{
         Destination = "\\{0}\{1}" -f 
-            $Global:SRDSC.DSCPullServer.DSCPullServerName, 
+            $ENV:COMPUTERNAME, 
             $Global:SRDSC.DSCPullServer.DSCPullServerMOFPath
         Force = $true
     }
@@ -124,7 +124,7 @@ function Start-SRDSConfiguration {
 
     $MOFResourceCopyParams = @{
         Destination = "\\{0}\{1}" -f 
-            $Global:SRDSC.DSCPullServer.DSCPullServerName, 
+            $ENV:COMPUTERNAME, 
             $Global:SRDSC.DSCPullServer.DSCPullServerResourceModules
         Force = $true
     }

--- a/Module/SRDSC.psm1
+++ b/Module/SRDSC.psm1
@@ -2,7 +2,8 @@
 # Test if Git is Installed
 
 try {
-    git --version
+    # Must use .exe to not use git-override.
+    git.exe --version
 } catch {
     Throw "Git is required for SRDSC. Please install git."
     return

--- a/_Build/BuildModule.ps1
+++ b/_Build/BuildModule.ps1
@@ -37,7 +37,7 @@ $ModuleManifestParams = @{
 Get-ChildItem "$ModuleDirectory\Public" -Recurse -File | Select-Object {
     $ModuleManifestParams.FunctionsToExport += $_.BaseName
 }
-Get-ChildItem "$ModuleDirectory\Public" -Recurse -File | ForEach-Object {
+Get-ChildItem "$ModuleDirectory\Private" -Recurse -File | ForEach-Object {
     if ((Get-Content $_.FullName) -match 'Export-ModuleMember') {
         $ModuleManifestParams.FunctionsToExport += $_.BaseName
     }

--- a/_Build/BuildVersion.txt
+++ b/_Build/BuildVersion.txt
@@ -1,2 +1,3 @@
 0.0.1-alpha
 0.0.2-alpha
+0.0.3-alpha


### PR DESCRIPTION
Fixes the following bugs:

1. When importing the module, some private commands need to be exportable. This process is skipped causing issues.
2. When importing the module, it would call 'git', which would abstract to a helper function (which hasn't been loaded), causing a circular issue. This was resolved by change git to git.exe forcing the executable to be triggered.
3. When Initialize-SRDSC provisions the Script Runner target. It sets the wrong target, causing scripts to launch, but not have access to the local profile.
4. Fix encoding issues with Add-SRDSCNode. VSCode was encoding files incorrectly, causing errors to be raised when executed.
5. Fixed issue with Start-SRDSCConfiguration, where the build script was not completing correctly.
6. Changed LCM Configuration mode to be 'ApplyAndAutoCorrect'